### PR TITLE
Fix $this->debug() fatal error case

### DIFF
--- a/libraries/Curl.php
+++ b/libraries/Curl.php
@@ -332,6 +332,8 @@ class Curl
 
             $this->error_code = $errno;
             $this->error_string = $error;
+            
+            $this->last_response = $this->response;
 
             return false;
         } else {


### PR DESCRIPTION
Define $this->last_response so $this->debug() doesn't cause fatal error when executing debug() when there wasn't an HTTP error.
